### PR TITLE
gap between thumbs and more elastic delegate

### DIFF
--- a/YSRangeSlider/YSRangeSlider.swift
+++ b/YSRangeSlider/YSRangeSlider.swift
@@ -156,6 +156,8 @@ import UIKit
             rightThumbLayer.frame.size = CGSize(width: thumbsSize, height: thumbsSize)
         }
     }
+
+    @IBInspectable open var percentGapBetweenThumbs: CGFloat = 0.05
     
     /// The delegate of `YSRangeSlider`
     open weak var delegate: YSRangeSliderDelegate?
@@ -170,6 +172,10 @@ import UIKit
     private let thumbTouchAreaExpansion: CGFloat = -90.0
     private var leftThumbSelected = false
     private var rightThumbSelected = false
+
+    private var gapBetweenThumbs: CGFloat {
+        return (maximumValue - minimumValue) * percentGapBetweenThumbs
+    }
     
     // MARK: - Init
     
@@ -259,9 +265,9 @@ import UIKit
         let selectedValue = percentage * (maximumValue - minimumValue) + minimumValue
         
         if leftThumbSelected {
-            minimumSelectedValue = (selectedValue < maximumSelectedValue) ? selectedValue : maximumSelectedValue
+            minimumSelectedValue = (selectedValue + gapBetweenThumbs < maximumSelectedValue) ? selectedValue : maximumSelectedValue - gapBetweenThumbs
         } else if rightThumbSelected {
-            maximumSelectedValue = (selectedValue > minimumSelectedValue) ? selectedValue : minimumSelectedValue
+            maximumSelectedValue = (selectedValue - gapBetweenThumbs > minimumSelectedValue) ? selectedValue : minimumSelectedValue + gapBetweenThumbs
         }
         
         return true

--- a/YSRangeSlider/YSRangeSlider.swift
+++ b/YSRangeSlider/YSRangeSlider.swift
@@ -293,7 +293,7 @@ import UIKit
         updateThumbsPosition()
         CATransaction.commit()
 
-        delegate?.rangeSliderDidChange?(self, minimumSelectedValue: minimumSelectedValue, maximumSelectedValue: maximumSelectedValue)
+        delegate?.rangeSliderDidChange(self, minimumSelectedValue: minimumSelectedValue, maximumSelectedValue: maximumSelectedValue)
     }
     
     private func updateThumbsPosition() {
@@ -343,7 +343,7 @@ extension CGRect {
 
 // MARK: - YSRangeSliderDelegate
 
-@objc public protocol YSRangeSliderDelegate: class {
+public protocol YSRangeSliderDelegate: class {
     /** Delegate function that is called every time minimum or maximum selected value is changed
      
     - Parameters:
@@ -353,5 +353,9 @@ extension CGRect {
     */
     func rangeSliderDidChangeWithUI(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
 
-    @objc optional func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
+    func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
+}
+
+extension YSRangeSliderDelegate {
+    func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat) {}
 }

--- a/YSRangeSlider/YSRangeSlider.swift
+++ b/YSRangeSlider/YSRangeSlider.swift
@@ -269,6 +269,8 @@ import UIKit
         } else if rightThumbSelected {
             maximumSelectedValue = (selectedValue - gapBetweenThumbs > minimumSelectedValue) ? selectedValue : minimumSelectedValue + gapBetweenThumbs
         }
+
+        delegate?.rangeSliderDidChangeWithUI(self, minimumSelectedValue: minimumSelectedValue, maximumSelectedValue: maximumSelectedValue)
         
         return true
     }
@@ -290,8 +292,8 @@ import UIKit
         CATransaction.setDisableActions(true)
         updateThumbsPosition()
         CATransaction.commit()
-        
-        delegate?.rangeSliderDidChange(self, minimumSelectedValue: minimumSelectedValue, maximumSelectedValue: maximumSelectedValue)
+
+        delegate?.rangeSliderDidChange?(self, minimumSelectedValue: minimumSelectedValue, maximumSelectedValue: maximumSelectedValue)
     }
     
     private func updateThumbsPosition() {
@@ -349,5 +351,7 @@ public protocol YSRangeSliderDelegate: class {
         - minimumSelectedValue: The minimum selected value
         - maximumSelectedValue: The maximum selected value
     */
-    func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
+    func rangeSliderDidChangeWithUI(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
+
+    optional func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
 }

--- a/YSRangeSlider/YSRangeSlider.swift
+++ b/YSRangeSlider/YSRangeSlider.swift
@@ -343,7 +343,7 @@ extension CGRect {
 
 // MARK: - YSRangeSliderDelegate
 
-public protocol YSRangeSliderDelegate: class {
+@objc public protocol YSRangeSliderDelegate: class {
     /** Delegate function that is called every time minimum or maximum selected value is changed
      
     - Parameters:
@@ -353,5 +353,5 @@ public protocol YSRangeSliderDelegate: class {
     */
     func rangeSliderDidChangeWithUI(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
 
-    optional func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
+    @objc optional func rangeSliderDidChange(_ rangeSlider: YSRangeSlider, minimumSelectedValue: CGFloat, maximumSelectedValue: CGFloat)
 }


### PR DESCRIPTION
Added feature for making gap between thumbs, it's restricted them from "sticky" to each other.

And made delegate more complex. Before it was called on any changes, program and ui. It's hard to track such changes outside, so I made another method to a delegate - one to notice when program changes appear and another to notice when UI-driven changes appear